### PR TITLE
Fix defmanifest macro

### DIFF
--- a/src/system.clj
+++ b/src/system.clj
@@ -14,13 +14,15 @@
   (println event (or message "") (or opts "")))
 
 (s/def ::config :system.config/config-spec)
-(s/def ::descripton string?)
+(s/def ::description string?)
 (s/def ::manifest (s/keys :opt-un [::config ::description]))
 
 (defmacro defmanifest [manifest]
-  (when-not (s/valid? ::manifest manifest)
-    (throw (ex-info "Invalid manifest" (s/explain-data ::manifest manifest))))
-  (list 'def 'manifest manifest))
+  `(let [result# (s/conform ~::manifest ~manifest)]
+     (if (= :clojure.spec.alpha/invalid result#)
+       (throw (ex-info "Invalid manifest"
+                       (s/explain-data ~::manifest ~manifest)))
+       (def ~(symbol "manifest") result#))))
 
 (defn- new-system [ & [config]]
   {:system (atom {:system/config (or config {})})})

--- a/test/system_test.clj
+++ b/test/system_test.clj
@@ -19,7 +19,7 @@
    :events {:define {}
             :subscribe {}}})
 
-(system/defhook authorize
+#_(system/defhook authorize
   {:description "authorization framework"}
   [context param hooks]
 
@@ -155,3 +155,30 @@
     )
 
   )
+
+(deftest test-defmanifest
+  (testing "when validator is an atom"
+    (is (macroexpand '(system/defmanifest
+                        {:config {:port {:type "integer"
+                                         :validator pos-int?}}}))
+        "Unexpected error during macro expansion"))
+  (testing "when validator is a list"
+    (is (macroexpand '(system/defmanifest
+                        {:config {:filepath {:type "string"
+                                             :validator (complement empty?)}}}))
+        "Unexpected error during macro expansion")
+    (is (macroexpand '(system/defmanifest
+                        {:config {:url {:type "string"
+                                        :validator #(clojure.string/starts-with? % "http")}}}))
+        "Unexpected error during macro expansion"))
+  (testing "when manifest doesn't conform to the schema"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid manifest"
+         (system/defmanifest {:description 123}))
+        "Non-conforming description must throw")
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid manifest"
+         (system/defmanifest {:config "invalid"}))
+        "Non-conforming config must throw")))


### PR DESCRIPTION
Make sure it doesn't throw exceptions at expansion time. Also make it evaluate the argument before validating it with clojure.spec, because the manifest may contain Clojure code, and you want to validate the result, not the code itself.

tl;dr just try running the tests with the old macro, and then with the new one